### PR TITLE
text-align: justify all over the site

### DIFF
--- a/caimconsulting/static/css/style.css
+++ b/caimconsulting/static/css/style.css
@@ -41,6 +41,7 @@ a:focus {
 p {
   padding: 0;
   margin: 0 0 30px 0;
+  text-align: justify;
 }
 
 h1,

--- a/mainsite/templates/index.html
+++ b/mainsite/templates/index.html
@@ -559,7 +559,7 @@
                   <div class="container" >
                     <h5 class="font-weight-bold mb-1">{{ advisor.name }}</h5>
                     <hr style=" margin : 0px 0px 5px 0px">
-                    <p class="text-uppercase blue-text">
+                    <p class="text-uppercase blue-text" style="text-align: center;">
                       {{ advisor.position }}
                     </p>
                   </div>


### PR DESCRIPTION
Fixes #14 

Affected sections:
* `About Us` section
* `Services` section cards
* `Why Choose Us?` section cards
* Footer paragraph on Caim Consulting
* Publication texts
* Individual Advisor Bio pages